### PR TITLE
Fixed an Issue due to bad defined global variables

### DIFF
--- a/src/passthru_shadow.h
+++ b/src/passthru_shadow.h
@@ -38,7 +38,7 @@
 #define PASSTHRU_SHADOW_GET_TOPIC             "$aws/things/%s/shadow/get"
 #define PASSTHRU_SHADOW_GET_ACCEPTED_TOPIC    "$aws/things/%s/shadow/get/accepted"
 
-char DELTA_REPORT[SHADOW_MAX_SIZE_OF_RX_BUFFER];
+static char DELTA_REPORT[SHADOW_MAX_SIZE_OF_RX_BUFFER];
 
 typedef struct {
   int *type;


### PR DESCRIPTION
The linker complained about several definitions of DELTA_REPORT which got fixed by making it a static variable